### PR TITLE
Add `-L` flag to usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Features:
 
 launch command:
 ```
-nelua --script path/to/nelua-lsp.lua
+nelua -L path/to/nelua-lsp-folder/ --script path/to/nelua-lsp.lua
 ```


### PR DESCRIPTION
hello im trying to make nelua-lsp available in neovim lspconfig, but it would be preferable to have a defined place for this, i tried not using `-L` flag but i can't find info on how nelua finds lua libraries, according to `--help` it seeks for init.nelua files

also im not sure if this is a correct place for this on windows
and `/usr/lib/` looks like a proper place since its where lua-language-server is located